### PR TITLE
Add mapping failure error message

### DIFF
--- a/lift_over.py
+++ b/lift_over.py
@@ -61,6 +61,8 @@ def _main():
                     ref = record[3] if new_strand == '+' else reverse_complement(record[3])
                     alt = record[4] if new_strand == '+' else reverse_complement(record[4])
                     print '\t'.join([new_chrom, new_pos, record[2], ref, alt] + record[5:])
+                else:
+                    print >>sys.stderr, '{0},{1} mapping failed!'.format(record[0],record[1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes people want to know which loci failed. In my case, I want to provide both hg19 and b38 version under the same set of markers.